### PR TITLE
Updated VSCode Debug Client

### DIFF
--- a/DebugClients.md
+++ b/DebugClients.md
@@ -61,11 +61,11 @@ Screenshots:
 <a href="https://raw.githubusercontent.com/dzzie/duk4vb/master/vb_examples/with_debug/screenshot.png">screenshot1</a>.</td>
 </tr>
 <tr>
-<td><a href="https://github.com/harold-b/musashi-vscode-deubgger">Musashi debugger</a></td>
+<td><a href="https://marketplace.visualstudio.com/items?itemName=HaroldBrenes.duk-debug">VSCode duk-debug</a></td>
 <td>TCP</td>
 <td>binary</td>
-<td>Visual Studio Code debugger extension for Duktape runtime.  Screenshots:
-<a href="https://github.com/harold-b/musashi-vscode-deubgger/blob/master/img/musa-debug.gif">screenshot1</a>,
+<td><a href="https://code.visualstudio.com">Visual Studio Code</a> debugger extension for the Duktape runtime. <br />Source: <a href="https://github.com/harold-b/vscode-duktape-debug">https://github.com/harold-b/vscode-duktape-debug</a><br /> Screenshots:
+<a href="https://raw.githubusercontent.com/harold-b/vscode-duktape-debug/master/img/musa-debug.gif">screenshot1</a>,
 <a href="https://camo.githubusercontent.com/02a89271785ba8a040ca82bfa64405db3a7b6538/68747470733a2f2f692e696d67736166652e6f72672f663132383562322e676966">screenshot2</a>.</td>
 </tr>
 </table>


### PR DESCRIPTION
I updated my VSCode debugger client extension to run on **v1.5.0** and I limited it to the vanilla duktape functionality (that is, local scope only as opposed to the version I preliminary version I had before which used my modified runtime to inspect closures).

I also published an initial extension to the market place, so I updated the links on the wiki page to point to the extension page [(link)](https://marketplace.visualstudio.com/items?itemName=HaroldBrenes.duk-debug) and I also added the link to the proper repository, as I've deprecated the older one.

One should be able to simply install the extension and get to debugging now easily.

I didn't add myself to the 'AUTHORS.rst' because I thought this modification was too trivial to warrant it.

*PS: Do you have a logo for duktape? I didn't know what to set as the extension icon.*