### PR TITLE
Add a configuring page for 2.x

### DIFF
--- a/Configuring.md
+++ b/Configuring.md
@@ -1,172 +1,50 @@
 # Configuring Duktape for build
 
-## Duktape 1.3 to 1.5
+## Duktape 2.x
 
-In Duktape 1.3 there are three supported ways of configuring Duktape features
-for build:
+See [[Configuring Duktape 2.x for build|Configuring2x]].
 
-* Use the `duk_config.h` in the distributable (`src/duk_config.h` or
-  `src-separate/duk_config.h`).  If default features are not desirable,
-  provide `DUK_OPT_xxx` feature options when compiling both Duktape and
-  the application.  This matches Duktape 1.2, but there's an external
-  `duk_config.h` header:
+## Duktape 1.x
 
-  ```
-  # src/ contains default duk_config.h (comes with distributable)
-  $ gcc -std=c99 -Os -o hello -Isrc -DDUK_OPT_FASTINT \
-          src/duktape.c hello.c -lm
-  ```
+See [[Configuring Duktape 1.x for build|Configuring1x]].
 
-* Generate a new autodetect `duk_config.h` using `genconfig` with config
-  option overrides given either on the command line or in YAML/header
-  files.  For example, to enable fastint support and to disable
-  bufferobjects:
+## Options for specific environments
 
-  ```
-  $ sudo apt-get install python-yaml
+### Timing sensitive
 
-  $ python config/genconfig.py \
-          --metadata config/genconfig_metadata.tar.gz \
-          --output myinclude/duk_config.h \
-          -DDUK_USE_FASTINT \
-          -UDUK_USE_BUFFEROBJECT_SUPPORT \
-          autodetect-header
+Timing sensitive applications include e.g. games.  For such environments
+steady, predictable performance is important, often more important than
+absolute performance.  Duktape provides some options to improve use in these
+environments; for instance, you can disable automatic mark-and-sweep and rely
+on reference counting and manually requested mark-and-sweep for garbage
+collection.
 
-  # Ensure myinclude/duk_config.h comes first in include path.
-  $ gcc -std=c99 -Os -o hello -Imyinclude -Isrc \
-          src/duktape.c hello.c -lm
-  ```
+See:
 
-  There are several alternatives to defining option overrides, see:
-  https://github.com/svaarala/duktape/blob/master/doc/duk-config.rst#genconfig-option-overrides
+* [timing-sensitive.rst](https://github.com/svaarala/duktape/blob/master/doc/timing-sensitive.rst)
+* [timing_sensitive.yaml](https://github.com/svaarala/duktape/blob/master/config/examples/timing_sensitive.yaml)
 
-* Edit `duk_config.h` manually.  This is a bit messy but allows everything
-  to be modified, e.g. typedefs and `#include` directives.
+### Memory constrained
 
-## Duktape 1.2
+Duktape can work in 192kB flash memory (code footprint) and 64kB system
+RAM (including Duktape and a minimal OS), and provides a lot of feature
+options to minimize memory footprint.  These feature options are often
+useful for systems with less than 256kB of system RAM.
 
-In Duktape 1.2 Duktape features are configured through feature options:
+See:
 
-* If defaults are acceptable, compile Duktape as is.  For example:
+* [low-memory.rst](https://github.com/svaarala/duktape/blob/master/doc/low-memory.rst)
+* [low_memory.yaml](https://github.com/svaarala/duktape/blob/master/config/examples/low_memory.yaml)
+* [low_memory_strip.yaml](https://github.com/svaarala/duktape/blob/master/config/examples/low_memory_strip.yaml)
 
-  ```
-  $ gcc -std=c99 -Os -o hello -Isrc src/duktape.c hello.c -lm
-  ```
+### Performance sensitive
 
-* Otherwise use `DUK_OPT_xxx` feature options on the compiler command line
-  when compiling both Duktape and your application (if they're compiled
-  separately).  For example:
+The default Duktape build has reasonable performance options for most
+environments.  Even so there are some feature options which
+may be used to improve performance by e.g. enabling fast paths, enabling
+"fastint" support, or trading some API safety for performance.
 
-  ```
-  $ gcc -std=c99 -Os -o hello -Isrc -DDUK_OPT_FASTINT \
-          src/duktape.c hello.c -lm
-  ```
+See:
 
-  For available feature options, see:
-  https://github.com/svaarala/duktape/blob/master/doc/feature-options.rst
-
-* When compiling Duktape as a Windows DLL, you must define `DUK_OPT_DLL_BUILD`
-  for both Duktape and application build.  For example:
-
-  ```
-  > cl /O2 /W3 /DDUK_OPT_DLL_BUILD /Isrc /LD src\duktape.c
-  > cl /O2 /W3 /DDUK_OPT_DLL_BUILD /Fehello.exe /Isrc hello.c duktape.lib
-  > hello.exe
-  ```
-
-The table below summarizes the most commonly needed feature options, in no
-particular order:
-
-<table>
-<thead>
-<tr>
-<th>Define</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>DUK_OPT_DLL_BUILD</td>
-<td>Build Duktape as a DLL, affects symbol visibility declarations.
-    Most concretely, enables <code>__declspec(dllexport)</code> and
-    <code>__declspec(dllimport)</code> on Windows builds.  This option
-    must be used also for application build when Duktape is linked as
-    a DLL (otherwise <code>__declspec(dllimport)</code> won't be used).</td>
-</tr>
-<tr>
-<td>DUK_OPT_NO_PACKED_TVAL</td>
-<td>Don't use the packed 8-byte internal value representation even if otherwise
-    possible.  The packed representation has more platform/compiler portability
-    issues than the unpacked one.</td>
-</tr>
-<tr>
-<td>DUK_OPT_FORCE_ALIGN</td>
-<td>Use <code>-DDUK_OPT_FORCE_ALIGN=4</code> or <code>-DDUK_OPT_FORCE_ALIGN=8</code>
-    to force a specific struct/value alignment instead of relying on Duktape's
-    automatic detection.  This shouldn't normally be needed.</td>
-</tr>
-<tr>
-<td>DUK_OPT_FORCE_BYTEORDER</td>
-<td>Use this to skip byte order detection and force a specific byte order:
-    <code>1</code> for little endian, <code>2</code> for ARM "mixed" endian
-    (integers little endian, IEEE doubles mixed endian), <code>3</code> for
-    big endian.  Byte order detection relies on unstandardized platform
-    specific header files, so this may be required for custom platforms if
-    compilation fails in endianness detection.</td>
-</tr>
-<tr>
-<td>DUK_OPT_NO_REFERENCE_COUNTING</td>
-<td>Disable reference counting and use only mark-and-sweep for garbage collection.
-    Although this reduces memory footprint of heap objects, the downside is much
-    more fluctuation in memory usage.</td>
-</tr>
-<tr>
-<td>DUK_OPT_NO_MARK_AND_SWEEP</td>
-<td>Disable mark-and-sweep and use only reference counting for garbage collection.
-    This reduces code footprint and eliminates garbage collection pauses, but
-    objects participating in unreachable reference cycles won't be collected until
-    the Duktape heap is destroyed.  In particular, function instances won't be
-    collected because they're always in a reference cycle with their default
-    prototype object.  Unreachable objects are collected if you break reference
-    cycles manually (and are always freed when a heap is destroyed).</td>
-</tr>
-<tr>
-<td>DUK_OPT_NO_VOLUNTARY_GC</td>
-<td>Disable voluntary periodic mark-and-sweep collection.  A mark-and-sweep
-    collection is still triggered in an out-of-memory condition.  This option
-    should usually be combined with reference counting, which collects all
-    non-cyclical garbage.  Application code should also request an explicit
-    garbage collection from time to time when appropriate.  When this option
-    is used, Duktape will have no garbage collection pauses in ordinary use,
-    which is useful for timing sensitive applications like games.</td>
-</tr>
-<tr>
-<td>DUK_OPT_TRACEBACK_DEPTH</td>
-<td>Override default traceback collection depth.  The default is currently 10.</td>
-</tr>
-<tr>
-<td>DUK_OPT_NO_FILE_IO</td>
-<td>Disable use of ANSI C file I/O which might be a portability issue on some
-    platforms.  Causes <code>duk_eval_file()</code> to throw an error,
-    makes built-in <code>print()</code> and <code>alert()</code> no-ops,
-    and suppresses writing of a panic message to <code>stderr</code> on panic.
-    This option does not suppress debug printing so don't enable debug printing
-    if you wish to avoid I/O.</td>
-</tr>
-<tr>
-<td>DUK_OPT_PANIC_HANDLER(code,msg)</td>
-<td>Provide a custom panic handler, see detailed description below.</td>
-</tr>
-<tr>
-<td>DUK_OPT_SELF_TESTS</td>
-<td>Perform run-time self tests when a Duktape heap is created.  Catches
-    platform/compiler problems which cannot be reliably detected during
-    compile time.  Not enabled by default because of the extra footprint.</td>
-</tr>
-<tr>
-<td>DUK_OPT_ASSERTIONS</td>
-<td>Enable internal assert checks.  These slow down execution considerably
-    so only use when debugging.</td>
-</tr>
-</tbody>
-</table>
+* [performance-sensitive.rst](https://github.com/svaarala/duktape/blob/master/doc/performance-sensitive.rst)
+* [performance_sensitive.rst](https://github.com/svaarala/duktape/blob/master/config/examples/performance_sensitive.yaml)

--- a/Configuring1x.md
+++ b/Configuring1x.md
@@ -1,0 +1,172 @@
+# Configuring Duktape 1.x for build
+
+## Duktape 1.3 to 1.7
+
+In Duktape 1.3 there are three supported ways of configuring Duktape features
+for build:
+
+* Use the `duk_config.h` in the distributable (`src/duk_config.h` or
+  `src-separate/duk_config.h`).  If default features are not desirable,
+  provide `DUK_OPT_xxx` feature options when compiling both Duktape and
+  the application.  This matches Duktape 1.2, but there's an external
+  `duk_config.h` header:
+
+  ```
+  # src/ contains default duk_config.h (comes with distributable)
+  $ gcc -std=c99 -Os -o hello -Isrc -DDUK_OPT_FASTINT \
+          src/duktape.c hello.c -lm
+  ```
+
+* Generate a new autodetect `duk_config.h` using `genconfig` with config
+  option overrides given either on the command line or in YAML/header
+  files.  For example, to enable fastint support and to disable
+  bufferobjects:
+
+  ```
+  $ sudo apt-get install python-yaml
+
+  $ python config/genconfig.py \
+          --metadata config/genconfig_metadata.tar.gz \
+          --output myinclude/duk_config.h \
+          -DDUK_USE_FASTINT \
+          -UDUK_USE_BUFFEROBJECT_SUPPORT \
+          autodetect-header
+
+  # Ensure myinclude/duk_config.h comes first in include path.
+  $ gcc -std=c99 -Os -o hello -Imyinclude -Isrc \
+          src/duktape.c hello.c -lm
+  ```
+
+  There are several alternatives to defining option overrides, see:
+  https://github.com/svaarala/duktape/blob/master/doc/duk-config.rst#genconfig-option-overrides
+
+* Edit `duk_config.h` manually.  This is a bit messy but allows everything
+  to be modified, e.g. typedefs and `#include` directives.
+
+## Duktape 1.2
+
+In Duktape 1.2 Duktape features are configured through feature options:
+
+* If defaults are acceptable, compile Duktape as is.  For example:
+
+  ```
+  $ gcc -std=c99 -Os -o hello -Isrc src/duktape.c hello.c -lm
+  ```
+
+* Otherwise use `DUK_OPT_xxx` feature options on the compiler command line
+  when compiling both Duktape and your application (if they're compiled
+  separately).  For example:
+
+  ```
+  $ gcc -std=c99 -Os -o hello -Isrc -DDUK_OPT_FASTINT \
+          src/duktape.c hello.c -lm
+  ```
+
+  For available feature options, see:
+  https://github.com/svaarala/duktape/blob/master/doc/feature-options.rst
+
+* When compiling Duktape as a Windows DLL, you must define `DUK_OPT_DLL_BUILD`
+  for both Duktape and application build.  For example:
+
+  ```
+  > cl /O2 /W3 /DDUK_OPT_DLL_BUILD /Isrc /LD src\duktape.c
+  > cl /O2 /W3 /DDUK_OPT_DLL_BUILD /Fehello.exe /Isrc hello.c duktape.lib
+  > hello.exe
+  ```
+
+The table below summarizes the most commonly needed feature options, in no
+particular order:
+
+<table>
+<thead>
+<tr>
+<th>Define</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>DUK_OPT_DLL_BUILD</td>
+<td>Build Duktape as a DLL, affects symbol visibility declarations.
+    Most concretely, enables <code>__declspec(dllexport)</code> and
+    <code>__declspec(dllimport)</code> on Windows builds.  This option
+    must be used also for application build when Duktape is linked as
+    a DLL (otherwise <code>__declspec(dllimport)</code> won't be used).</td>
+</tr>
+<tr>
+<td>DUK_OPT_NO_PACKED_TVAL</td>
+<td>Don't use the packed 8-byte internal value representation even if otherwise
+    possible.  The packed representation has more platform/compiler portability
+    issues than the unpacked one.</td>
+</tr>
+<tr>
+<td>DUK_OPT_FORCE_ALIGN</td>
+<td>Use <code>-DDUK_OPT_FORCE_ALIGN=4</code> or <code>-DDUK_OPT_FORCE_ALIGN=8</code>
+    to force a specific struct/value alignment instead of relying on Duktape's
+    automatic detection.  This shouldn't normally be needed.</td>
+</tr>
+<tr>
+<td>DUK_OPT_FORCE_BYTEORDER</td>
+<td>Use this to skip byte order detection and force a specific byte order:
+    <code>1</code> for little endian, <code>2</code> for ARM "mixed" endian
+    (integers little endian, IEEE doubles mixed endian), <code>3</code> for
+    big endian.  Byte order detection relies on unstandardized platform
+    specific header files, so this may be required for custom platforms if
+    compilation fails in endianness detection.</td>
+</tr>
+<tr>
+<td>DUK_OPT_NO_REFERENCE_COUNTING</td>
+<td>Disable reference counting and use only mark-and-sweep for garbage collection.
+    Although this reduces memory footprint of heap objects, the downside is much
+    more fluctuation in memory usage.</td>
+</tr>
+<tr>
+<td>DUK_OPT_NO_MARK_AND_SWEEP</td>
+<td>Disable mark-and-sweep and use only reference counting for garbage collection.
+    This reduces code footprint and eliminates garbage collection pauses, but
+    objects participating in unreachable reference cycles won't be collected until
+    the Duktape heap is destroyed.  In particular, function instances won't be
+    collected because they're always in a reference cycle with their default
+    prototype object.  Unreachable objects are collected if you break reference
+    cycles manually (and are always freed when a heap is destroyed).</td>
+</tr>
+<tr>
+<td>DUK_OPT_NO_VOLUNTARY_GC</td>
+<td>Disable voluntary periodic mark-and-sweep collection.  A mark-and-sweep
+    collection is still triggered in an out-of-memory condition.  This option
+    should usually be combined with reference counting, which collects all
+    non-cyclical garbage.  Application code should also request an explicit
+    garbage collection from time to time when appropriate.  When this option
+    is used, Duktape will have no garbage collection pauses in ordinary use,
+    which is useful for timing sensitive applications like games.</td>
+</tr>
+<tr>
+<td>DUK_OPT_TRACEBACK_DEPTH</td>
+<td>Override default traceback collection depth.  The default is currently 10.</td>
+</tr>
+<tr>
+<td>DUK_OPT_NO_FILE_IO</td>
+<td>Disable use of ANSI C file I/O which might be a portability issue on some
+    platforms.  Causes <code>duk_eval_file()</code> to throw an error,
+    makes built-in <code>print()</code> and <code>alert()</code> no-ops,
+    and suppresses writing of a panic message to <code>stderr</code> on panic.
+    This option does not suppress debug printing so don't enable debug printing
+    if you wish to avoid I/O.</td>
+</tr>
+<tr>
+<td>DUK_OPT_PANIC_HANDLER(code,msg)</td>
+<td>Provide a custom panic handler, see detailed description below.</td>
+</tr>
+<tr>
+<td>DUK_OPT_SELF_TESTS</td>
+<td>Perform run-time self tests when a Duktape heap is created.  Catches
+    platform/compiler problems which cannot be reliably detected during
+    compile time.  Not enabled by default because of the extra footprint.</td>
+</tr>
+<tr>
+<td>DUK_OPT_ASSERTIONS</td>
+<td>Enable internal assert checks.  These slow down execution considerably
+    so only use when debugging.</td>
+</tr>
+</tbody>
+</table>

--- a/Configuring2x.md
+++ b/Configuring2x.md
@@ -1,0 +1,147 @@
+# Configuring Duktape 2.x for build
+
+## Overview
+
+Duktape distributable contains prepared source files and a multi-platform
+autodetecting `duk_config.h` for Duktape default configuration:
+
+```
+$ tar xvfJ duktape-2.0.0.tar.xz; cd duktape-2.0.0
+$ ls -l src
+total 3400
+-rw-rw-r-- 1 duktape duktape  114927 Aug 30 03:57 duk_config.h
+-rw-rw-r-- 1 duktape duktape   48651 Aug 30 03:57 duk_source_meta.json
+-rw-rw-r-- 1 duktape duktape 3238266 Aug 30 03:57 duktape.c
+-rw-rw-r-- 1 duktape duktape   68213 Aug 30 03:57 duktape.h
+```
+
+You can include these in your build directly: ensure include path provides
+access to `duk_config.h` and `duktape.h`, and add `duktape.c` to the set of
+C files built.
+
+If you want to use custom Duktape configuration options, use
+`tools/configure.py`.  For example:
+
+```
+$ tar xvfJ duktape-2.0.0.tar.xz; cd duktape-2.0.0
+
+# Create an empty temporary directory
+$ rm -rf /tmp/output; mkdir /tmp/output
+
+# Custom configuration:
+#   - Low memory configuration
+#   - Enable fastint support on top of low memory configuration
+#   - Enable ROM built-in support
+#   - DLL mode, affects Windows build (declspec declarations)
+$ python tools/configure.py \
+      --output-directory /tmp/output \
+      --source-directory src-input \
+      --config-metadata config \
+      --option-file profiles/config/low_memory.yaml \
+      -DDUK_USE_FASTINT \
+      --rom-support \
+      --dll
+
+# The output directory will get prepared config and sources.
+# Include them in your build.
+$ ls -l /tmp/output
+total 4324
+-rw-rw-r-- 1 duktape duktape   91440 Aug 30 04:42 duk_config.h
+-rw-rw-r-- 1 duktape duktape   48653 Aug 30 04:42 duk_source_meta.json
+-rw-rw-r-- 1 duktape duktape 4213240 Aug 30 04:42 duktape.c
+-rw-rw-r-- 1 duktape duktape   68201 Aug 30 04:42 duktape.h
+```
+
+The `configure.py` tool has a lot of options, use `--help` to view option list.
+The minimum options (to create sources with default options) are:
+
+```
+# Default configuration, combined (amalgamated) sources.
+$ python tools/configure.py \
+      --output-directory /tmp/output \
+      --source-directory src-input \
+      --config-metadata config
+```
+
+However, `--source-directory` and `--config-metadata` will automatically
+default (relative to the configure.py script path) so that usually only
+the output directory needs to be specified:
+
+```
+$ python tools/configure.py \
+      --output-directory /tmp/output
+```
+
+See also:
+
+* https://github.com/svaarala/duktape/tree/master/doc/duk-config.rst:
+  detailed documentation of using configure.py (genconfig.py in Duktape
+  1.x) with examples.
+
+* https://github.com/svaarala/duktape/tree/master/config/config-options:
+  metadata for available config options.
+
+* https://github.com/svaarala/duktape/blob/master/src/builtins.yaml:
+  built-in object metadata, and a description of how to write metadata
+  files to edit built-in objects or add new built-in bindings.
+
+## Differerences to 1.x:
+
+* All configuration options are expressed in `duk_config.h`, and the compiler
+  command line `DUK_OPT_xxx` feature options have been removed.
+
+* The `configure.py` tool subsumes `genconfig.py`: it generates both a
+  `duk_config.h` and prepared sources matching the configuration.  This makes
+  it possible to modify built-in Ecmascript objects, modify Unicode tables,
+  etc, from the end user distributable without having to use the main repo.
+
+* You can still use `genconfig.py` as a separate tool.  However, it's
+  recommended to use `configure.py` instead.
+
+## Common options
+
+### Fatal error handler (RECOMMENDED)
+
+It is **strongly recommended** that you provide a default fatal error
+handler:
+
+* `-DDUK_USE_FATAL_HANDLER`
+
+Example fatal error handler macro:
+
+```
+'-DDUK_USE_FATAL_HANDLER(udata,msg)=do { const char *fatal_msg = (msg); fprintf(stderr, "*** FATAL ERROR: %s\n", fatal_msg ? fatal_msg : "no message"); abort(); } while (0)'
+```
+
+### Windows DLL
+
+When building a Windows DLL, use the `--dll` option in configure.py.
+
+### Avoid packed duk_tval
+
+On some platforms the IEEE 754 bit representation tricks used for the
+8-byte packed `duk_tval` won't work.  You can force unpacked duk_tval
+representation using:
+
+* `-UDUK_USE_PACKED_TVAL`
+
+### Troubleshooting
+
+* `-DDUK_USE_ASSERTIONS`: enable assertions.  Assertion failures trigger a
+  fatal error, so you should also defined a fatal error handler.  Note that
+  assertions have a large impact on footprint and performance, so don't keep
+  them enabled in production builds.
+
+* `-DDUK_USE_SELF_TESTS`: enable self tests, often very useful in diagnosis.
+  Self test failures cause debug prints and assertion failures.
+
+* `-DDUK_USE_DEBUG`, `-DDUK_USE_DEBUG_LEVEL=0`, and `-DDUK_USE_DEBUG_WRITE`:
+  enable debug logging.
+
+When using debug logging, you must provide a `DUK_USE_DEBUG_WRITE` macro for
+the actual debug log writes.  This allows you to retarget the debug logging
+to wherever is most appropriate for you application.  Example:
+
+```
+'-DDUK_USE_DEBUG_WRITE(level,file,line,func,msg)=do {fprintf(stderr, "D%ld %s:%ld (%s): %s\n", (long) (level), (file), (long) (line), (func), (msg));} while(0)'
+```

--- a/DevelopmentSetup.md
+++ b/DevelopmentSetup.md
@@ -33,8 +33,8 @@ The following are optional but useful:
 * Git command line tools used to get "git describe" and other version
   metadata.
 
-* A minifier (Closure or UglifyJS2) for some Ecmascript code embedded in
-  the build.
+* Duktape 1.x: a minifier (Closure or UglifyJS2) for some Ecmascript code
+  embedded in the build.  This dependency was removed in Duktape 2.x.
 
 After making changes to Duktape sources, metadata, etc:
 
@@ -56,10 +56,12 @@ dist package such as `duktape-1.4.0.tar.xz`.  Some notes:
   directory as long as you give the git version metadata as command line
   options.
 
-* The optional minifier is used for a very small Ecmascript initialization
-  script (`src/duk_initjs.js`) embedded into the Duktape build.  If you don't
-  provide a minifier using `--minify` the script won't be minified.  The
-  impact on footprint is very small, around 500 bytes.
+* The optional minifier is used in Duktape 1.x for a very small Ecmascript
+  initialization script (`src/duk_initjs.js`) embedded into the Duktape build.
+  If you don't provide a minifier using `--minify` the script won't be
+  minified.  The impact on footprint is very small, around 500 bytes.
+  Duktape 2.x no longer embeds this initialization script so a minifier is
+  not required.
 
 Creating a dist package is the minimum step needed to work with a private fork
 effectively.  As such, the dist process has been made quite portable and should

--- a/HowtoDecodeBytecode.md
+++ b/HowtoDecodeBytecode.md
@@ -16,7 +16,7 @@ With that caveat, here are some resources to decode the bytecode opcode format
 if you want to do so e.g. in a debug client:
 
 * Bytecode header defines:
-  https://github.com/svaarala/duktape/blob/master/src/duk_js_bytecode.h
+  https://github.com/svaarala/duktape/blob/master/src-input/duk_js_bytecode.h
 
 * Bytecode metadata used by the Node.js debugger web UI to decode instructions
   into a printable form:
@@ -25,6 +25,10 @@ if you want to do so e.g. in a debug client:
 * Node.js debugger web UI decoder/formatting function:
   https://github.com/svaarala/duktape/blob/v1.4.0/debugger/duk_debug.js#L1044-L1133
   (link is for 1.4.0; check master for the most recent version)
+
+Note that bytecode format has changed between versions.  There was a large
+bytecode rework between Duktape 1.x and 2.x, but there are also significant
+changes between minor versions.
 
 ## Decoding dump/load bytecode format
 


### PR DESCRIPTION
- [x] Split configuring page to 1.x and 2.x
- [x] Add 2.x configuration page
- [x] Mention `DUK_USE_FATAL_HANDLER` prominently in 2.x configuring page, with an example, because it's very strongly recommended
