### PR TITLE
Improvements to pandoc conversion process

### DIFF
--- a/Configuring.md
+++ b/Configuring.md
@@ -2,11 +2,11 @@
 
 ## Duktape 2.x
 
-See [[Configuring Duktape 2.x for build|Configuring2x]].
+See [Configuring Duktape 2.x for build](Configuring2x.md).
 
 ## Duktape 1.x
 
-See [[Configuring Duktape 1.x for build|Configuring1x]].
+See [Configuring Duktape 1.x for build](Configuring1x.md).
 
 ## Options for specific environments
 

--- a/GettingStartedPrimalityTesting.md
+++ b/GettingStartedPrimalityTesting.md
@@ -1,6 +1,6 @@
 # Getting started: primality testing
 
-The [[Getting started: line processing|GettingStartedLineProcessing]] example
+The [Getting started: line processing](GettingStartedLineProcessing.md) example
 illustrated how C code can call into Ecmascript to do things that are easy
 in Ecmascript but difficult in C.
 
@@ -87,7 +87,7 @@ is quite straightforward to implement.  Adding a program main and a simple
 * <https://github.com/svaarala/duktape/blob/master/examples/guide/primecheck.c>
 
 The new calls compared to
-[[Getting started: line processing|GettingStartedLineProcessing]]
+[Getting started: line processing](GettingStartedLineProcessing.md)
 are, line by line:
 
 ```c

--- a/Home.md
+++ b/Home.md
@@ -21,63 +21,63 @@ Welcome to the official Duktape Wiki!
 
 ## Getting started
 
-* [[Getting started: line processing|GettingStartedLineProcessing]]
-* [[Getting started: primality testing|GettingStartedPrimalityTesting]]
+* [Getting started: line processing](GettingStartedLineProcessing.md)
+* [Getting started: primality testing](GettingStartedPrimalityTesting.md)
 
 ## How-To
 
-* [[How to handle fatal errors|HowtoFatalErrors]]
-* [[How to work with value stack types|HowtoValueStackTypes]]
-* [[How to make function calls|HowtoFunctionCalls]]
-* [[How to use virtual properties|HowtoVirtualProperties]]
-* [[How to use finalization|HowtoFinalization]]
-* [[How to work with buffers|HowtoBuffers]] ([[Duktape 1.x|HowtoBuffers1x]] [[Duktape 2.x|HowtoBuffers2x]])
-* [[How to work with lightfuncs|HowtoLightfuncs]]
-* [[How to use modules|HowtoModules]]
-* [[How to use coroutines|HowtoCoroutines]]
-* [[How to use logging|HowtoLogging]]
-* [[How to persist object references in native code|HowtoNativePersistentReferences]]
-* [[How to write a native constructor function|HowtoNativeConstructor]]
-* [[How to iterate over an array|HowtoIterateArray]]
-* [[How to augment error objects|HowtoAugmentErrorObjects]]
-* [[How to decode Duktape bytecode|HowtoDecodeBytecode]]
-* [[How to work with non-BMP characters|HowtoNonBmpCharacters]]
-* [[How to get a reference to the global object|HowtoGlobalObjectReference]]
-* [[How to run on bare metal platforms|HowtoBareMetal]]
-* [[How to enable debug prints|HowtoDebugPrints]]
+* [How to handle fatal errors](HowtoFatalErrors.md)
+* [How to work with value stack types](HowtoValueStackTypes.md)
+* [How to make function calls](HowtoFunctionCalls.md)
+* [How to use virtual properties](HowtoVirtualProperties.md)
+* [How to use finalization](HowtoFinalization.md)
+* [How to work with buffers](HowtoBuffers.md) ([Duktape 1.x](HowtoBuffers1x.md), [Duktape 2.x](HowtoBuffers2x.md))
+* [How to work with lightfuncs](HowtoLightfuncs.md)
+* [How to use modules](HowtoModules.md)
+* [How to use coroutines](HowtoCoroutines.md)
+* [How to use logging](HowtoLogging.md)
+* [How to persist object references in native code](HowtoNativePersistentReferences.md)
+* [How to write a native constructor function](HowtoNativeConstructor.md)
+* [How to iterate over an array](HowtoIterateArray.md)
+* [How to augment error objects](HowtoAugmentErrorObjects.md)
+* [How to decode Duktape bytecode](HowtoDecodeBytecode.md)
+* [How to work with non-BMP characters](HowtoNonBmpCharacters.md)
+* [How to get a reference to the global object](HowtoGlobalObjectReference.md)
+* [How to run on bare metal platforms](HowtoBareMetal.md)
+* [How to enable debug prints](HowtoDebugPrints.md)
 
 ## Frequently asked questions
 
-* [[Development setup for developing Duktape|DevelopmentSetup]]
-* [[Internal and external prototype|InternalExternalPrototype]]
-* [[API C types|ApiCTypes]]
-* [[Post-ES5 features|PostEs5Features]]
+* [Development setup for developing Duktape](DevelopmentSetup.md)
+* [Internal and external prototype](InternalExternalPrototype.md)
+* [API C types](ApiCTypes.md)
+* [Post-ES5 features](PostEs5Features.md)
 
 ## Config and feature options
 
-* [[Configuring Duktape for build|Configuring]]
-* [[Feature options|FeatureOptions]] (DUK_OPT_xxx) used as compiler command line options (up to Duktape 1.3)
-* [[Config options|ConfigOptions]] (DUK_USE_xxx) used in [duk_config.h](https://github.com/svaarala/duktape/blob/master/doc/duk-config.rst)
+* [Configuring Duktape for build](Configuring.md)
+* [Config options](ConfigOptions.md) (DUK_USE_xxx) used in [duk_config.h](https://github.com/svaarala/duktape/blob/master/doc/duk-config.rst)
+* Feature options (DUK_OPT_XXX) used as compiler command line options (up to Duktape 1.3), see https://github.com/svaarala/duktape/tree/master/config/feature-options
 
 ## Portability and compatibility
 
-* [[Portability|Portability]] notes for various compilers and target, compilation and troubleshooting tips
+* [Portability](Portability.md) notes for various compilers and target, compilation and troubleshooting tips
 * platforms
 * architectures
 * compilers
 * standard libraries: musl, uclibc
-* [[Compatibility with TypeScript|CompatibilityTypeScript]]
+* [Compatibility with TypeScript](CompatibilityTypeScript.md)
 
 ## Performance
 
 * <http://duktape.org/benchmarks.html>
-* [[How to optimize performance|Performance]]
-* [[Duktape 1.3.0 performance measurement|Performance130]]
-* [[Duktape 1.4.0 performance measurement|Performance140]]
-* [[Duktape 1.5.0 performance measurement|Performance150]]
-* [[Duktape 2.0.0 performance measurement|Performance200]]
-* [[Duktape 2.1.0 performance measurement|Performance210]]
-* [[Duktape 2.2.0 performance measurement|Performance220]]
+* [How to optimize performance](Performance.md)
+* [Duktape 1.3.0 performance measurement](Performance130.md)
+* [Duktape 1.4.0 performance measurement](Performance140.md)
+* [Duktape 1.5.0 performance measurement](Performance150.md)
+* [Duktape 2.0.0 performance measurement](Performance200.md)
+* [Duktape 2.1.0 performance measurement](Performance210.md)
+* [Duktape 2.2.0 performance measurement](Performance220.md)
 
 ## Low memory optimization
 
@@ -87,8 +87,8 @@ Welcome to the official Duktape Wiki!
 
 ## Miscellaneous
 
-* [[Projects using Duktape|ProjectsUsingDuktape]]
-* [[Debug clients|DebugClients]]
+* [Projects using Duktape](ProjectsUsingDuktape.md)
+* [Debug clients](DebugClients.md)
 
 ## Contributing, copyright, and license
 

--- a/HowtoBuffers.md
+++ b/HowtoBuffers.md
@@ -2,6 +2,6 @@
 
 The buffer bindings have changed between major versions, see:
 
-* [[How to work with buffers in Duktape 1.x|HowtoBuffers1x]]
+* [How to work with buffers in Duktape 1.x](HowtoBuffers1x.md)
 
-* [[How to work with buffers in Duktape 2.x|HowtoBuffers2x]]
+* [How to work with buffers in Duktape 2.x](HowtoBuffers2x.md)

--- a/HowtoFunctionCalls.md
+++ b/HowtoFunctionCalls.md
@@ -14,7 +14,7 @@ matters a bit:
   return value.  The "this" binding is initialized to a "default instance"
   and the return value has special handling, allowing the default instance to
   be replaced.  See
-  [[Internal and external prototype|InternalExternalPrototype]].
+  [Internal and external prototype](InternalExternalPrototype.md).
 
 The C API provides protected and unprotected variants.  Their difference is
 that protected calls catch errors; an error is indicated by the C API call

--- a/HowtoLightfuncs.md
+++ b/HowtoLightfuncs.md
@@ -48,7 +48,7 @@ limitations, with the most important being:
   used as constructors, but the default instance created will always inherit
   from Object.prototype.  The native function can overwrite the prototype
   explicitly, or return a "replacement value".  See
-  [[How to write a native constructor function|HowtoNativeConstructor]].
+  [How to write a native constructor function](HowtoNativeConstructor.md).
 
 Example of a lightfunc name:
 

--- a/InternalExternalPrototype.md
+++ b/InternalExternalPrototype.md
@@ -14,7 +14,7 @@ in Duktape documentation for clarity.
 
 See also:
 
-* [[How to write a native constructor function|HowtoNativeConstructor]]
+* [How to write a native constructor function](HowtoNativeConstructor.md)
 
 * <https://developer.mozilla.org/en/docs/Web/JavaScript/Inheritance_and_the_prototype_chain>
 
@@ -181,4 +181,4 @@ instance will inherit from `Object.prototype` unless you:
 
 * Editi the internal prototype of an instance after its creation.
 
-See: [[How to write a native constructor function|HowtoNativeConstructor]].
+See: [How to write a native constructor function](HowtoNativeConstructor.md).

--- a/build_pandoc.sh
+++ b/build_pandoc.sh
@@ -1,6 +1,11 @@
 STATIC_SITE=/srv/duktape-wiki
+MARKUP=markdown  # commonmark
 
 set -e  # exit on error
+
+if [ ! -d $STATIC_SITE ]; then
+    echo "Invalid static site: $STATIC_SITE"
+fi
 
 cd /tmp
 rm -rf wiki-rebuild-tmp
@@ -42,9 +47,10 @@ for fn in /tmp/wiki-rebuild-tmp/duktape-wiki/*.md; do
     # --toc ?
     # --title ?
     echo $fn
-    pandoc -r commonmark --highlight-style haddock -w html5 \
+    pandoc -r $MARKUP --highlight-style haddock -w html5 \
         --css style-top.css \
         --css github-pandoc-adapted.css \
+        --include-in-header in_header.html \
         --include-before-body before_body.html \
         --include-after-body after_body.html \
         -o "${fn%%.md}.html" "$fn"
@@ -57,6 +63,7 @@ for fn in /tmp/wiki-rebuild-tmp/duktape-wiki/*.rst; do
     pandoc -r rst --highlight-style haddock -w html5 \
         --css style-top.css \
         --css github-pandoc-adapted.css \
+        --include-in-header in_header.html \
         --include-before-body before_body.html \
         --include-after-body after_body.html \
         -o "${fn%%.rst}.html" "$fn"
@@ -65,3 +72,10 @@ done
 cp /tmp/wiki-rebuild-tmp/duktape-wiki/*.html /tmp/wiki-output-tmp/
 cp /tmp/wiki-rebuild-tmp/duktape/website/style-top.css /tmp/wiki-output-tmp/
 cp /tmp/wiki-rebuild-tmp/duktape-wiki/github-pandoc-adapted.css /tmp/wiki-output-tmp/
+
+# Copy final site on success to statically served site
+if [ ! -d $STATIC_SITE ]; then
+    echo "Invalid static site: $STATIC_SITE"
+fi
+rm -rf $STATIC_SITE/*
+cp -r /tmp/wiki-output-tmp/* $STATIC_SITE/

--- a/convert_links.py
+++ b/convert_links.py
@@ -58,7 +58,8 @@ def convert(fn):
             link = link + '>'
         return link + tail
 
-    # Take care of Gollum-supported links first.
+    # Take care of Gollum-supported links first, converting them to .md links.
+    # (These should no longer occur in the repo, so a no-op.)
     data = re.sub(re_wikilink1, _repl1, data)
 
     # Then change (or insert) link suffix .html.

--- a/in_header.html
+++ b/in_header.html
@@ -1,0 +1,36 @@
+<script type="text/javascript">
+// allows non-javascript browsers to render with fallback fonts
+document.getElementsByTagName("html")[0].className = "";
+
+/*
+  WebFont.load({
+    google: {
+      families: ['Open Sans', 'Droid Sans Mono']
+    }
+  });
+*/
+// link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'
+// link href='http://fonts.googleapis.com/css?family=Droid+Sans+Mono' rel='stylesheet' type='text/css'
+
+WebFontConfig = {
+    google: {
+      families: ['Open Sans', 'Droid Sans Mono']
+    }
+};
+
+// http://kevindew.me/post/47052453532/a-fallback-for-when-google-web-font-loader-fails
+(function() {
+    var wf = document.createElement('script');
+    wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+        '://ajax.googleapis.com/ajax/libs/webfont/1.4.2/webfont.js';
+    wf.type = 'text/javascript';
+    wf.async = 'true';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(wf, s);
+    setTimeout(function() {
+        if (!("WebFont" in window)) {
+            document.getElementsByTagName("html")[0].className += " wf-fail";
+        }
+    }, 1000);
+})();
+</script>


### PR DESCRIPTION
- Convert links in repo to plain .md links: this works in Github and Wiki directly which is nice.
- Add missing final site copy command.
- Improve font styling.