### PR TITLE
Fix example of DUK_USE_DEBUG_WRITE in duk_config.h

### DIFF
--- a/HowtoDebugPrints.md
+++ b/HowtoDebugPrints.md
@@ -21,8 +21,8 @@ Example of `DUK_USE_DEBUG_WRITE` in manually edited `duk_config.h`:
 
 ```c
 #define DUK_USE_DEBUG_WRITE(level,file,line,func,msg) do { \
-		fprintf(stderr, "D%ld %s:%d (%s): %s\n", \
-		        (long) (level), (file), (long) (line), (func), (msg));
+		fprintf(stderr, "D%ld %s:%ld (%s): %s\n", \
+		        (long) (level), (file), (long) (line), (func), (msg)); \
 	} while (0)
 ```
 


### PR DESCRIPTION
- Format string now consistent with parameters and sample configure.py argument
- add a missing backslash

spotted as a result of discussion in svaarala/duktape#1971