### PR TITLE
Add libjsmisc and libjssql to the projects page

### DIFF
--- a/ProjectsUsingDuktape.md
+++ b/ProjectsUsingDuktape.md
@@ -127,6 +127,14 @@
 <td>Perl binding for Duktape</td>
 </tr>
 <tr>
+<td><a href="https://github.com/mindbit/libjsmisc" target="_blank">libjsmisc</a></td>
+<td>Small utility library for embeddable JavaScript, built on top of the Duktape engine</td>
+</tr>
+<tr>
+<td><a href="https://github.com/mindbit/libjssql" target="_blank">libjssql</a></td>
+<td>Database connectivity library that implements a JDBC-like API for JavaScript, based on the Duktape engine - currently supporting MySQL/MariaDB and PostgreSQL</td>
+</tr>
+<tr>
 <td><a href="https://github.com/ldx/libpac" target="_blank">libpac</a></td>
 <td>Using Duktape to parse proxy PAC files</td>
 </tr>


### PR DESCRIPTION
I would like to add libjsmisc and libjssql to the "Projects using Duktape" wiki page. I created a separate pull request against the main Duktape repo to add myself to the AUTHORS.rst file, and it was merged.

Note: libjssql is particularly interesting, because it provides database connectivity from the JavaScript environment (using a JDBC-like API) to any program using Duktape. It's basically a Duktape extension for database access rather than a library that uses Duktape.