### PR TITLE
Add Mailfilter to the projects page

### DIFF
--- a/ProjectsUsingDuktape.md
+++ b/ProjectsUsingDuktape.md
@@ -143,6 +143,10 @@
 <td>low.js is a port of the JavaScript runtime Node.js with far lower system requirements, allowing it to run on cheap, power-efficient microcontroller boards based on the ESP32-WROVER module</td>
 </tr>
 <tr>
+<td><a href="https://github.com/mindbit/mailfilter" target="_blank">Mailfilter</a></td>
+<td>SMTP server/client with embedded JavaScript support</td>
+</tr>
+<tr>
 <td><a href="https://github.com/megous/megatools" target="_blank">Megatools</a></td>
 <td>Using Duktape for main program logic</td>
 </tr>


### PR DESCRIPTION
I would like to add Mailfilter to the "Projects using Duktape" wiki page. I'm already in the AUTHORS.rst file of the main repo, so this should be pretty straightforward.

I would also like to kindly ask to also update the live wiki page at https://wiki.duktape.org/projectsusingduktape when this PR is merged. I added two other projects there ~2 years ago, and it looks like it still hasn't been updated. Thanks in advance!